### PR TITLE
Feature/replace auto generated item text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "yini-cli",
-    "version": "0.1.0",
+    "version": "1.0.0-alpha.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "yini-cli",
-            "version": "0.1.0",
+            "version": "1.0.0-alpha.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "commander": "^11.0.0",
+                "commander": "^14.0.0",
                 "yini-parser": "^1.0.1-beta"
             },
             "bin": {
-                "yini": "bin/yini.js"
+                "yini": "dist/index.js"
             },
             "devDependencies": {
                 "@eslint/js": "^9.31.0",
@@ -1902,12 +1902,12 @@
             "license": "MIT"
         },
         "node_modules/commander": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+            "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
             "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=20"
             }
         },
         "node_modules/concat-map": {
@@ -2918,16 +2918,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/lint-staged/node_modules/commander": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-            "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=20"
             }
         },
         "node_modules/listr2": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     },
     "author": "Marko K. Seppänen",
     "dependencies": {
-        "commander": "^11.0.0",
+        "commander": "^14.0.0",
         "yini-parser": "^1.0.1-beta"
     },
     "devDependencies": {

--- a/src/descriptions.ts
+++ b/src/descriptions.ts
@@ -1,6 +1,6 @@
 export const descriptions = {
-    yini: 'CLI for parsing and validating YINI config files',
-    'For-command-info': 'Show extended information (details, links, etc.)',
-    'For-command-parse': 'Parse a YINI file and print the result',
-    'For-command-validate': 'Checks if the file can be parsed as valid YINI',
+    yini: 'CLI for parsing and validating YINI config files.',
+    'For-command-info': 'Show extended information (details, links, etc.).',
+    'For-command-parse': 'Parse a YINI file and print the result.',
+    'For-command-validate': 'Checks if the file can be parsed as valid YINI.',
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,10 @@ Current suggestion:
 */
 
 // Display help for command
-program.name('yini').description(descripts.yini).version(pkg.version)
+program
+    .name('yini')
+    .description(descripts.yini)
+    .version(pkg.version, '-v, --version', 'Output the version number.')
 
 program.addHelpText(
     'before',

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { printInfo } from './commands/info.js'
 import { parseFile } from './commands/parse.js'
 import { validateFile } from './commands/validate.js'
 import { isDebug } from './config/env.js'
-import { descriptions as descripts } from './descriptions.js'
+import { descriptions as descr } from './descriptions.js'
 import { debugPrint, toPrettyJSON } from './utils/print.js'
 
 const require = createRequire(import.meta.url)
@@ -61,8 +61,11 @@ Current suggestion:
 // Display help for command
 program
     .name('yini')
-    .description(descripts.yini)
+    .description(descr.yini)
+    // Below will replace all auto-registered items (especially the descriptions starting with a capital and ending with a period).
     .version(pkg.version, '-v, --version', 'Output the version number.')
+    .helpOption('-h, --help', 'Display help for command.')
+    .helpCommand('help [command]', 'Display help for command.')
 
 program.addHelpText(
     'before',
@@ -88,21 +91,6 @@ More info: https://github.com/YINI-lang/yini-parser
 
 //program.command('help [command]').description('Display help for command')
 
-// Command info
-program
-    .command('info')
-    // .command('')
-    .description(descripts['For-command-info'])
-    // .option('info')
-    .action((options) => {
-        debugPrint('Run command "info"')
-        if (isDebug()) {
-            console.log('options:')
-            console.log(toPrettyJSON(options))
-        }
-        printInfo()
-    })
-
 /**
  *
  * Maybe later, to as default command: parse <parse>
@@ -125,7 +113,7 @@ program
 // Explicit "parse" command
 program
     .command('parse <file>')
-    .description(descripts['For-command-parse'])
+    .description(descr['For-command-parse'])
     .option('--strict', 'Parse YINI in strict-mode')
     .option('--pretty', 'Pretty-print output as JSON')
     // .option('--log', 'Use console.log output format (compact, quick view)')
@@ -163,11 +151,11 @@ program
  */
 program
     .command('validate <file>')
-    .description(descripts['For-command-validate'])
+    .description(descr['For-command-validate'])
     .option('--strict', 'Enable parsing in strict-mode')
     .option(
         '--details',
-        'Print detailed meta-data info (e.g., key count, nesting, etc.)',
+        'Print detailed meta-data info (e.g., key count, nesting, etc.).',
     )
     .option('--silent', 'Suppress output')
     .action((file, options) => {
@@ -177,6 +165,21 @@ program
         } else {
             program.help()
         }
+    })
+
+// Command info
+program
+    .command('info')
+    // .command('')
+    .description(descr['For-command-info'])
+    // .option('info')
+    .action((options) => {
+        debugPrint('Run command "info"')
+        if (isDebug()) {
+            console.log('options:')
+            console.log(toPrettyJSON(options))
+        }
+        printInfo()
     })
 
 // NOTE: Converting YINI files to other formats than json and js.

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -48,9 +48,9 @@ describe('Test general yini CLI usage:', () => {
     /*
      * Note: --version and -V are generated automatically by Commander.
      */
-    it('1.b) The yini command "-V" (uppecase) correctly outputs version.', async () => {
+    it('1.b) The yini command "-v" (lowercase) correctly outputs version.', async () => {
         // Arrange and Act.
-        const { stdout } = await yiniCLI(`-V`)
+        const { stdout } = await yiniCLI(`-v`)
         debugPrint('Test: 1:')
         debugPrint('stdout:')
         printObject(stdout)


### PR DESCRIPTION
- Updated commander to latest version 14 (new fetures and bugfixes, etc)
- Customized help output for all auto-generated items (options `--help`, `--version`, and command `help [command]` )
- For version It's lowercase `-v` now, overridden with custom flags
